### PR TITLE
nodejs: Use util.TextEncoder as polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ runners     : 10
 fillrandom  : 823.87 ms total; 82.39 us/op
 ```
 
+## Compatibility
+
+|node.js|Deno|
+|-|-|
+|`>=v10.0.0`|WIP|
+
 ## License
 
 [MIT License](./LICENSE)

--- a/port/node/index.ts
+++ b/port/node/index.ts
@@ -1,11 +1,18 @@
 import fs from "fs";
 import os from "os";
+import { TextEncoder } from "util";
 import InternalDatabase from "../../src/Database";
 import { Env, FileHandle } from "../../src/Env";
 import { DatabaseOptions } from "../../src/Options";
 import { InternalDBRepairer } from "../../src/DBRepairer";
 import { WriteBatch } from "../../src/WriteBatch";
 import { onExit } from "./cleanup";
+
+//@ts-ignore
+if (!global.TextEncoder) {
+  //@ts-ignore
+  global.TextEncoder = TextEncoder;
+}
 
 class NodeEnv implements Env {
   platform(): string {


### PR DESCRIPTION
As `TextEncoder` is not a global object in node.js under version v11.0.0, it will cause `ReferenceError: TextEncoder is not defined`(#148). 

This PR solved this with code：
```ts
import { TextEncoder } from 'util'

if (!global.TextEncoder) {
  global.TextEncoder = TextEncoder;
}
```

